### PR TITLE
Call methods on main thread if required

### DIFF
--- a/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
+++ b/ios/RNVoipPushNotification/RNVoipPushNotificationManager.m
@@ -119,12 +119,14 @@ RCT_EXPORT_MODULE();
     NSLog(@"[RNVoipPushNotificationManager] voipRegistration");
 
     dispatch_queue_t mainQueue = dispatch_get_main_queue();
-    // Create a push registry object
-    PKPushRegistry * voipRegistry = [[PKPushRegistry alloc] initWithQueue: mainQueue];
-    // Set the registry's delegate to AppDelegate
-    voipRegistry.delegate = (RNVoipPushNotificationManager *)RCTSharedApplication().delegate;
-    // Set the push type to VoIP
-    voipRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+    dispatch_async(mainQueue, ^{
+      // Create a push registry object
+      PKPushRegistry * voipRegistry = [[PKPushRegistry alloc] initWithQueue: mainQueue];
+      // Set the registry's delegate to AppDelegate
+      voipRegistry.delegate = (RNVoipPushNotificationManager *)RCTSharedApplication().delegate;
+      // Set the push type to VoIP
+      voipRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+    });
 }
 
 - (NSDictionary *)checkPermissions
@@ -193,8 +195,10 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
     if (RCTRunningInAppExtension()) {
         return;
     }
+  dispatch_async(dispatch_get_main_queue(), ^{
     [self registerUserNotification:permissions];
     [self voipRegistration];
+  });
 }
 
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)


### PR DESCRIPTION
Hi.

While using this lib, some warnings are shown in Xcode console like below,
and it seems that some methods must be called on main thread.

This PR fixes this problem. Thanks.

```
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIApplication registerUserNotificationSettings:]
PID: 498, TID: 239918, Thread name: (none), Queue name: com.facebook.react.RNVoipPushNotificationManagerQueue, QoS: 0
Backtrace:
4   pc                                  0x0000000101b688d8 -[RNVoipPushNotificationManager registerUserNotification:] + 552
5   pc                                  0x0000000101b695f0 -[RNVoipPushNotificationManager requestPermissions:] + 92
6   CoreFoundation                      0x00000001847caad0 <redacted> + 144
7   CoreFoundation                      0x00000001846a936c <redacted> + 292
8   CoreFoundation                      0x00000001846ade1c <redacted> + 60
9   pc                                  0x0000000101976324 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
10  pc                                  0x0000000101a1b030 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
11  pc                                  0x0000000101a1abc0 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
12  pc                                  0x0000000101a1ab30 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
13  libdispatch.dylib                   0x0000000103ac52cc _dispatch_call_block_and_release + 24
14  libdispatch.dylib                   0x0000000103ac528c _dispatch_client_callout + 16
15  libdispatch.dylib                   0x0000000103ad3f80 _dispatch_queue_serial_drain + 696
16  libdispatch.dylib                   0x0000000103ac87ec _dispatch_queue_invoke + 332
17  libdispatch.dylib                   0x0000000103ad4f6c _dispatch_root_queue_drain_deferred_wlh + 428
18  libdispatch.dylib                   0x0000000103adc020 _dispatch_workloop_worker_thread + 652
19  libsystem_pthread.dylib             0x00000001843eaf1c _pthread_wqthread + 932
20  libsystem_pthread.dylib             0x00000001843eab6c start_wqthread + 4
2018-10-02 15:13:38.470781+0900 pc[498:239918] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication registerUserNotificationSettings:]
PID: 498, TID: 239918, Thread name: (none), Queue name: com.facebook.react.RNVoipPushNotificationManagerQueue, QoS: 0
Backtrace:
4   pc                                  0x0000000101b688d8 -[RNVoipPushNotificationManager registerUserNotification:] + 552
5   pc                                  0x0000000101b695f0 -[RNVoipPushNotificationManager requestPermissions:] + 92
6   CoreFoundation                      0x00000001847caad0 <redacted> + 144
7   CoreFoundation                      0x00000001846a936c <redacted> + 292
8   CoreFoundation                      0x00000001846ade1c <redacted> + 60
9   pc                                  0x0000000101976324 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
10  pc                                  0x0000000101a1b030 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
11  pc                                  0x0000000101a1abc0 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
12  pc                                  0x0000000101a1ab30 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
13  libdispatch.dylib                   0x0000000103ac52cc _dispatch_call_block_and_release + 24
14  libdispatch.dylib                   0x0000000103ac528c _dispatch_client_callout + 16
15  libdispatch.dylib                   0x0000000103ad3f80 _dispatch_queue_serial_drain + 696
16  libdispatch.dylib                   0x0000000103ac87ec _dispatch_queue_invoke + 332
17  libdispatch.dylib                   0x0000000103ad4f6c _dispatch_root_queue_drain_deferred_wlh + 428
18  libdispatch.dylib                   0x0000000103adc020 _dispatch_workloop_worker_thread + 652
19  libsystem_pthread.dylib             0x00000001843eaf1c _pthread_wqthread + 932
20  libsystem_pthread.dylib             0x00000001843eab6c start_wqthread + 4
2018-10-02 15:13:38.777157+0900 pc[498:239918] [RNVoipPushNotificationManager] voipRegistration
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIApplication delegate]
PID: 498, TID: 239918, Thread name: (none), Queue name: com.facebook.react.RNVoipPushNotificationManagerQueue, QoS: 0
Backtrace:
4   pc                                  0x0000000101b689bc -[RNVoipPushNotificationManager voipRegistration] + 156
5   pc                                  0x0000000101b69608 -[RNVoipPushNotificationManager requestPermissions:] + 116
6   CoreFoundation                      0x00000001847caad0 <redacted> + 144
7   CoreFoundation                      0x00000001846a936c <redacted> + 292
8   CoreFoundation                      0x00000001846ade1c <redacted> + 60
9   pc                                  0x0000000101976324 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
10  pc                                  0x0000000101a1b030 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
11  pc                                  0x0000000101a1abc0 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
12  pc                                  0x0000000101a1ab30 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
13  libdispatch.dylib                   0x0000000103ac52cc _dispatch_call_block_and_release + 24
14  libdispatch.dylib                   0x0000000103ac528c _dispatch_client_callout + 16
15  libdispatch.dylib                   0x0000000103ad3f80 _dispatch_queue_serial_drain + 696
16  libdispatch.dylib                   0x0000000103ac87ec _dispatch_queue_invoke + 332
17  libdispatch.dylib                   0x0000000103ad4f6c _dispatch_root_queue_drain_deferred_wlh + 428
18  libdispatch.dylib                   0x0000000103adc020 _dispatch_workloop_worker_thread + 652
19  libsystem_pthread.dylib             0x00000001843eaf1c _pthread_wqthread + 932
20  libsystem_pthread.dylib             0x00000001843eab6c start_wqthread + 4
2018-10-02 15:13:38.833667+0900 pc[498:239918] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication delegate]
PID: 498, TID: 239918, Thread name: (none), Queue name: com.facebook.react.RNVoipPushNotificationManagerQueue, QoS: 0
Backtrace:
4   pc                                  0x0000000101b689bc -[RNVoipPushNotificationManager voipRegistration] + 156
5   pc                                  0x0000000101b69608 -[RNVoipPushNotificationManager requestPermissions:] + 116
6   CoreFoundation                      0x00000001847caad0 <redacted> + 144
7   CoreFoundation                      0x00000001846a936c <redacted> + 292
8   CoreFoundation                      0x00000001846ade1c <redacted> + 60
9   pc                                  0x0000000101976324 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
10  pc                                  0x0000000101a1b030 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
11  pc                                  0x0000000101a1abc0 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
12  pc                                  0x0000000101a1ab30 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
13  libdispatch.dylib                   0x0000000103ac52cc _dispatch_call_block_and_release + 24
14  libdispatch.dylib                   0x0000000103ac528c _dispatch_client_callout + 16
15  libdispatch.dylib                   0x0000000103ad3f80 _dispatch_queue_serial_drain + 696
16  libdispatch.dylib                   0x0000000103ac87ec _dispatch_queue_invoke + 332
17  libdispatch.dylib                   0x0000000103ad4f6c _dispatch_root_queue_drain_deferred_wlh + 428
18  libdispatch.dylib                   0x0000000103adc020 _dispatch_workloop_worker_thread + 652
19  libsystem_pthread.dylib             0x00000001843eaf1c _pthread_wqthread + 932
20  libsystem_pthread.dylib             0x00000001843eab6c start_wqthread + 4
```
